### PR TITLE
Stop the triage fireworks: label trigger replaces slash command

### DIFF
--- a/.github/workflows/pipeline-triage.lock.yml
+++ b/.github/workflows/pipeline-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"af4d55e386ab4169ae6bca248a1d1847d8ad811fe7351c85bc8ca016fd752d26","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a7c0a118803fcb007ce24e66858d6caa8cb23bfcadb98985b3b8ea7fc8c36bd8","compiler_version":"v0.71.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"v0.71.1","version":"v0.71.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28","digest":"sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.28@sha256:a8834e285807654bf680154faa710d43fe4365a0868142f5c20e48c85e137a7a"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28","digest":"sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.28@sha256:93290f2393752252911bd7c39a047f776c0b53063575e7bde4e304962a9a61cb"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28","digest":"sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.28@sha256:844c18280f82cd1b06345eb2f4e91966b34185bfc51c9f237c3e022e848fb474"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.0"},{"image":"ghcr.io/github/github-mcp-server:v1.0.2"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -48,65 +48,50 @@
 
 name: "Pipeline — Triage"
 "on":
-  discussion:
-    types:
-    - created
-    - edited
-  discussion_comment:
-    types:
-    - created
-    - edited
-  issue_comment:
-    types:
-    - created
-    - edited
   issues:
     types:
-    - opened
-    - edited
-    - reopened
-  pull_request:
-    types:
-    - opened
-    - edited
-    - reopened
-  pull_request_review_comment:
-    types:
-    - created
-    - edited
+    - labeled
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
+      item_number:
+        default: ""
+        description: The number of the issue, pull request, or discussion
+        required: false
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}"
+  group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}-${{ github.event.label.name || github.run_id }}"
 
 run-name: "Pipeline — Triage"
 
 jobs:
   activation:
     needs: pre_activation
-    if: "needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') || github.event_name == 'pull_request' && (startsWith(github.event.pull_request.body, '/triage ') || startsWith(github.event.pull_request.body, '/triage\n') || github.event.pull_request.body == '/triage') || github.event_name == 'discussion' && (startsWith(github.event.discussion.body, '/triage ') || startsWith(github.event.discussion.body, '/triage\n') || github.event.discussion.body == '/triage') || github.event_name == 'discussion_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage'))"
+    if: >
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'issues' && github.event.label.name == 'pipeline/triage-requested')
     runs-on: ubuntu-slim
     permissions:
       actions: read
       contents: read
-      discussions: write
       issues: write
-      pull-requests: write
     outputs:
-      body: ${{ steps.sanitized.outputs.body }}
       comment_id: ${{ steps.add-comment.outputs.comment-id }}
       comment_repo: ${{ steps.add-comment.outputs.comment-repo }}
       comment_url: ${{ steps.add-comment.outputs.comment-url }}
       engine_id: ${{ steps.generate_aw_info.outputs.engine_id }}
+      label_command: ${{ steps.remove_trigger_label.outputs.label_name }}
       lockdown_check_failed: ${{ steps.generate_aw_info.outputs.lockdown_check_failed == 'true' }}
       model: ${{ steps.generate_aw_info.outputs.model }}
       secret_verification_result: ${{ steps.validate-secret.outputs.verification_result }}
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-      slash_command: ${{ needs.pre_activation.outputs.matched_command }}
       stale_lock_file_failed: ${{ steps.check-lock-file.outputs.stale_lock_file_failed == 'true' }}
-      text: ${{ steps.sanitized.outputs.text }}
-      title: ${{ steps.sanitized.outputs.title }}
     steps:
       - name: Setup Scripts
         id: setup
@@ -201,17 +186,6 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_version_updates.cjs');
             await main();
-      - name: Compute current body text
-        id: sanitized
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/compute_text.cjs');
-            await main();
       - name: Add comment with workflow run link
         id: add-comment
         if: github.event_name == 'issues' || github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment' || github.event_name == 'discussion' || github.event_name == 'discussion_comment' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == github.repository_id
@@ -223,6 +197,17 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/add_workflow_run_comment.cjs');
+            await main();
+      - name: Remove trigger label
+        id: remove_trigger_label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          GH_AW_LABEL_NAMES: "[\"pipeline/triage-requested\"]"
+        with:
+          script: |
+            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
+            setupGlobals(core, github, context, exec, io, getOctokit);
+            const { main } = require('${{ runner.temp }}/gh-aw/actions/remove_trigger_label.cjs');
             await main();
       - name: Create prompt with built-in context
         env:
@@ -236,19 +221,18 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
         # poutine:ignore untrusted_checkout_exec
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_741b08d8d23e8870_EOF'
+          cat << 'GH_AW_PROMPT_a9995784f62f22ad_EOF'
           <system>
-          GH_AW_PROMPT_741b08d8d23e8870_EOF
+          GH_AW_PROMPT_a9995784f62f22ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_741b08d8d23e8870_EOF'
+          cat << 'GH_AW_PROMPT_a9995784f62f22ad_EOF'
           <safe-output-tools>
           Tools: add_comment, add_labels(max:3), remove_labels(max:7), dispatch_workflow, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -280,15 +264,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_741b08d8d23e8870_EOF
+          GH_AW_PROMPT_a9995784f62f22ad_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          if [ "$GITHUB_EVENT_NAME" = "issue_comment" ] && [ -n "$GH_AW_IS_PR_COMMENT" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review_comment" ] || [ "$GITHUB_EVENT_NAME" = "pull_request_review" ]; then
-            cat "${RUNNER_TEMP}/gh-aw/prompts/pr_context_prompt.md"
-          fi
-          cat << 'GH_AW_PROMPT_741b08d8d23e8870_EOF'
+          cat << 'GH_AW_PROMPT_a9995784f62f22ad_EOF'
           </system>
           {{#runtime-import .github/workflows/pipeline-triage.md}}
-          GH_AW_PROMPT_741b08d8d23e8870_EOF
+          GH_AW_PROMPT_a9995784f62f22ad_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -312,9 +293,7 @@ jobs:
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
-          GH_AW_IS_PR_COMMENT: ${{ github.event.issue.pull_request && 'true' || '' }}
           GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND: ${{ needs.pre_activation.outputs.matched_command }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -334,9 +313,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_IS_PR_COMMENT: process.env.GH_AW_IS_PR_COMMENT,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_MATCHED_COMMAND
+                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
               }
             });
       - name: Validate prompt placeholders
@@ -482,9 +459,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_df8f34441f5f75b2_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << GH_AW_SAFE_OUTPUTS_CONFIG_ed3d446b7edcca2d_EOF
           {"add_comment":{"max":1,"target":"triggering"},"add_labels":{"allowed":["bug","enhancement","feature","security","documentation","refactor","pipeline/triage","pipeline/planning"],"github-token":"${COPILOT_GITHUB_TOKEN}","max":3,"target":"triggering"},"create_report_incomplete_issue":{},"dispatch_workflow":{"aw_context_workflows":["pipeline-plan"],"max":1,"workflow_files":{"pipeline-plan":".lock.yml"},"workflows":["pipeline-plan"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["pipeline/triage","pipeline/planning","pipeline/implementing","pipeline/review","pipeline/awaiting-merge","pipeline/deploying","pipeline/done"],"github-token":"${COPILOT_GITHUB_TOKEN}","max":7,"target":"triggering"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_df8f34441f5f75b2_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_ed3d446b7edcca2d_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -736,7 +713,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9efd7689f96e8a06_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e157127b1241f470_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -777,7 +754,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9efd7689f96e8a06_EOF
+          GH_AW_MCP_CONFIG_e157127b1241f470_EOF
       - name: Clean git credentials
         continue-on-error: true
         run: bash "${RUNNER_TEMP}/gh-aw/actions/clean_git_credentials.sh"
@@ -883,7 +860,6 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_COMMAND: triage
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -1289,11 +1265,11 @@ jobs:
             await main();
 
   pre_activation:
-    if: "github.event_name == 'issues' && (startsWith(github.event.issue.body, '/triage ') || startsWith(github.event.issue.body, '/triage\n') || github.event.issue.body == '/triage') || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request == null || github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') && github.event.issue.pull_request != null || github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage') || github.event_name == 'pull_request' && (startsWith(github.event.pull_request.body, '/triage ') || startsWith(github.event.pull_request.body, '/triage\n') || github.event.pull_request.body == '/triage') || github.event_name == 'discussion' && (startsWith(github.event.discussion.body, '/triage ') || startsWith(github.event.discussion.body, '/triage\n') || github.event.discussion.body == '/triage') || github.event_name == 'discussion_comment' && (startsWith(github.event.comment.body, '/triage ') || startsWith(github.event.comment.body, '/triage\n') || github.event.comment.body == '/triage')"
+    if: github.event_name == 'issues' && github.event.label.name == 'pipeline/triage-requested'
     runs-on: ubuntu-slim
     outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' && steps.check_command_position.outputs.command_position_ok == 'true' }}
-      matched_command: ${{ steps.check_command_position.outputs.matched_command }}
+      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
       - name: Setup Scripts
@@ -1302,7 +1278,7 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-      - name: Check team membership for command workflow
+      - name: Check team membership for workflow
         id: check_membership
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
@@ -1313,17 +1289,6 @@ jobs:
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
-      - name: Check command position
-        id: check_command_position
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          GH_AW_COMMANDS: "[\"triage\"]"
-        with:
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_command_position.cjs');
             await main();
 
   safe_outputs:

--- a/.github/workflows/pipeline-triage.md
+++ b/.github/workflows/pipeline-triage.md
@@ -3,7 +3,9 @@ name: "Pipeline — Triage"
 description: "Classifies issues and kicks off the planning stage"
 
 on:
-  slash_command: triage
+  label_command:
+    name: pipeline/triage-requested
+    events: [issues]
 
 runs-on: ${{ vars.PIPELINE_RUNNER }}
 engine: copilot
@@ -36,12 +38,11 @@ safe-outputs:
 
 ## Pipeline — Triage Agent
 
-You are the intake agent for an AI-SDLC pipeline. When `rbmathis` comments `/triage` on an issue, you classify it and kick off the planning stage.
+You are the intake agent for an AI-SDLC pipeline. When the `pipeline/triage-requested` label is applied to an issue, you classify it and kick off the planning stage.
 
 ## Your Task
 
-1. **Verify** the workflow was triggered by an issue comment from `rbmathis` with the exact body `/triage`; if not, stop without taking any action
-2. **Apply the `pipeline/triage` label** to the issue immediately (remove any other `pipeline/*` labels first)
+1. **Apply the `pipeline/triage` label** to the issue immediately (remove any other `pipeline/*` labels first)
 3. **Read the issue** title and body carefully
 4. **Classify** the issue:
    - **Type**: bug, enhancement, feature, security, documentation, or refactor
@@ -81,7 +82,6 @@ You are the intake agent for an AI-SDLC pipeline. When `rbmathis` comments `/tri
 
 ## Important
 
-- Only run for issue comments from `rbmathis` whose exact body is `/triage`
 - Every triggered issue gets classified — never skip or reject
 - Always include `testing` if any implementation agents are assigned
 - Security issues always get `security` agent


### PR DESCRIPTION
## What's This?
Replaces the slash command trigger with a label_command trigger for pipeline triage.

## Quality Checks
- Skipped (no .NET changes - only YAML and Markdown)

## What Changed
- pipeline-triage.md: slash_command -> label_command: pipeline/triage-requested (issues only)
- pipeline-triage.lock.yml: recompiled, 82 fewer lines
- Agent instructions: removed slash command verification step

## Side Effects
Triage workflow only fires when the pipeline/triage-requested label is applied. Zero spurious re-triggers.

NOTE: Create the pipeline/triage-requested label in repo Settings -> Labels before merging.

Auto-generated by the Snarky Commit Skill
