### PR TITLE
Add Performance Budget Monitor — Core Web Vitals dashboard with thresholds

### DIFF
--- a/tests/Demo1.UnitTests/Integration/AppSmokeTests.cs
+++ b/tests/Demo1.UnitTests/Integration/AppSmokeTests.cs
@@ -32,6 +32,7 @@ public class AppSmokeTests : IClassFixture<WebApplicationFactory<Program>>
     [Theory]
     [InlineData("/")]
     [InlineData("/Home/Privacy")]
+    [InlineData("/Performance/Dashboard")]
     public async Task Get_CommonPages_ReturnsSuccess(string path)
     {
         using var client = _factory.CreateClient(new WebApplicationFactoryClientOptions

--- a/wwwroot/js/performance-observer.js
+++ b/wwwroot/js/performance-observer.js
@@ -246,6 +246,21 @@
         } catch (e) { /* FID not supported */ }
     }
 
+    // Collect TTFB from Navigation Timing API
+    function collectTTFB() {
+        try {
+            var navEntries = performance.getEntriesByType('navigation');
+            if (navEntries && navEntries.length > 0) {
+                var navEntry = navEntries[0];
+                var ttfb = navEntry.responseStart - navEntry.requestStart;
+                if (ttfb >= 0) {
+                    reportMetric('TTFB', ttfb, 'ms');
+                    updateStatus('TTFB', ttfb);
+                }
+            }
+        } catch (e) { /* Navigation Timing not supported */ }
+    }
+
     // Initialize on DOM ready
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init);
@@ -256,6 +271,8 @@
     function init() {
         initCharts();
         observeWebVitals();
+        // Collect TTFB after current synchronous stack clears so navigation entry is finalized
+        setTimeout(collectTTFB, 0);
         fetchHistory();
         // Refresh chart data periodically
         setInterval(fetchHistory, 30000);


### PR DESCRIPTION
## Summary

Completes the Performance Budget Monitor feature by adding the one missing functional piece: TTFB collection via the Navigation Timing API.

### Changes

**`wwwroot/js/performance-observer.js`** — Added `collectTTFB()` function that:
- Reads `performance.getEntriesByType('navigation')[0]` to compute `responseStart - requestStart`
- Calls `reportMetric('TTFB', ttfb, 'ms')` and `updateStatus('TTFB', ttfb)` when value ≥ 0
- Wrapped in try/catch for browsers without Navigation Timing support
- Called via `setTimeout(collectTTFB, 0)` inside `init()` so the navigation entry is finalized

**`tests/Demo1.UnitTests/Integration/AppSmokeTests.cs`** — Added `/Performance/Dashboard` to `Get_CommonPages_ReturnsSuccess` `[InlineData]`, exercising the full stack: controller → service → configuration → Razor view.

### Why This Approach

The `ServerTimingMiddleware` already measures TTFB server-side and writes the `Server-Timing` header. The browser-side script reads the Navigation Timing API directly (standard W3C, no CORS header exposure needed), completing the feedback loop: TTFB status card now activates with green/yellow/red on every page load.

Closes #134