### PR TITLE
🎓 docs agent moves out, gets its own pipeline stage

### DIFF
--- a/.github/agents/implement.agent.md
+++ b/.github/agents/implement.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Pipeline implementer — executes plans by writing code and delegating to specialists"
 tools: ['read', 'edit', 'search', 'execute', 'github', 'agent', 'todos']
-agents: ['backend', 'frontend', 'security', 'testing', 'docs', 'devops', 'build-validator']
+agents: ['backend', 'frontend', 'security', 'testing', 'build-validator']
 argument-hint: "Provide an issue number to implement (e.g., 'implement issue 135')"
 ---
 
@@ -34,14 +34,12 @@ Given an issue number:
    - `frontend` — Views, Razor templates, CSS, JavaScript
    - `security` — security fixes and hardening
    - `testing` — unit tests and integration tests
-   - `docs` — XML documentation and markdown docs
    - **After EACH task completes, post a brief progress comment on the issue** (e.g., "🧱 Task 2/5 welded: HomeController.cs forged. Moving on!")
-6. **Always invoke the `docs` agent** after implementation tasks complete to document what changed in the codebase (update XML comments, update any relevant docs/ markdown, add an inline summary of the change for tracking)
-7. **Run tests** — use `build-validator` to verify the build is clean and tests pass
-8. **Post a "Build Validated" comment** on the issue with the build/test result
-9. **Commit changes** with conventional commit messages
-10. **Push the branch** and **create a Pull Request**
-11. **Post the final status comment** on the issue
+6. **Run tests** — use `build-validator` to verify the build is clean and tests pass
+7. **Post a "Build Validated" comment** on the issue with the build/test result
+8. **Commit changes** with conventional commit messages
+9. **Push the branch** and **create a Pull Request**
+10. **Post the final status comment** on the issue
 
 ## Execution Process
 
@@ -62,12 +60,17 @@ For each task in dependency order:
    - What has been completed so far
    - Conventions to follow
 2. Verify output (no syntax errors, follows plan)
-3. Commit with conventional commit message:
+3. Commit with a snarky conventional commit message — follow the format but make the description POP:
    ```
-   feat(scope): description
+   feat(scope): description with attitude 🔨
 
    Part of #{issue-number}
    ```
+   Examples of the energy you're going for:
+   - `feat(controller): HomeController can now search without imploding 🔥`
+   - `fix(middleware): security headers were basically decorative — fixed that 💪`
+   - `test(controller): added tests because apparently we do that now ✅`
+   - `refactor(service): WeatherService no longer calls itself 47 times — you're welcome 🧱`
 
 ### Validate
 
@@ -124,7 +127,8 @@ We forged {N} pieces across {M} specialist crews. Every weld is solid:
 
 ## Commit Convention
 
-Use [Conventional Commits](https://www.conventionalcommits.org/):
+Use [Conventional Commits](https://www.conventionalcommits.org/) — but write the description like you mean it. The type and scope are boring structural requirements; the description is where your personality lives.
+
 - `feat(scope): description` — new features
 - `fix(scope): description` — bug fixes
 - `test(scope): description` — test additions
@@ -132,6 +136,12 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 - `refactor(scope): description` — code improvements
 
 Scopes: `controller`, `model`, `view`, `service`, `middleware`, `config`, `test`, `docs`
+
+**Commit message style rules:**
+- Describe what actually changed, but make it vivid — not `add search endpoint`, but `add search endpoint that actually returns results (wild concept)`
+- One well-placed emoji per message — don't go overboard
+- Keep it under 72 chars for the subject line, put extra context in the body
+- Never write `update`, `fix`, or `add` with no other detail — that's a war crime
 
 ## Guidelines
 

--- a/.github/agents/pipeline.agent.md
+++ b/.github/agents/pipeline.agent.md
@@ -1,7 +1,7 @@
 ---
-description: "AI-SDLC pipeline controller — auto-chains triage → plan → implement → review → land"
+description: "AI-SDLC pipeline controller — auto-chains triage → plan → implement → docs → review → land"
 tools: ['read', 'search', 'execute', 'github', 'agent', 'web']
-agents: ['triage', 'plan', 'implement', 'review', 'land']
+agents: ['triage', 'plan', 'implement', 'docs', 'review', 'land']
 argument-hint: "Say 'run issue 135' to run the full pipeline on an issue"
 ---
 
@@ -12,7 +12,7 @@ You are the **Pipeline Controller** — the orchestrator that drives the fully-a
 ## Pipeline Stages
 
 ```
-TRIAGE → PLAN → IMPLEMENT → REVIEW → LAND
+TRIAGE → PLAN → IMPLEMENT → DOCS → REVIEW → LAND
 ```
 
 ## How It Works
@@ -35,15 +35,22 @@ When invoked with an issue number, you execute each stage in sequence by delegat
 - **Delegate to:** `implement` agent
 - **Input:** issue number (implement agent reads the plan comment)
 - **Output:** working code, PR created
-- **GitHub actions:** writes code, commits, pushes, creates PR
+- **GitHub actions:** writes code, runs build+tests+security, commits, pushes, creates PR
 
-### Stage 4: Review
+### Stage 4: Docs
+- **Delegate to:** `docs` agent
+- **Input:** issue number + PR number from implement output
+- **Output:** XML comments updated, relevant docs/ markdown updated
+- **GitHub actions:** reads the PR diff, documents what changed, commits doc updates to the feature branch
+- **Note:** If docs fails, report the failure but continue to review — docs is not a blocking gate
+
+### Stage 5: Review
 - **Delegate to:** `review` agent
 - **Input:** issue number (review agent finds the associated PR)
 - **Output:** review decision (approved or changes requested)
 - **GitHub actions:** reviews PR, posts findings
 
-### Stage 5: Land
+### Stage 6: Land
 - **Delegate to:** `land` agent
 - **Input:** issue number (land agent finds the approved PR)
 - **Output:** merged PR, label updated to local/done
@@ -79,6 +86,7 @@ After each stage completes, briefly report:
 ✅ Triage complete — classified as [type], [difficulty], [priority]
 ✅ Plan complete — {N} tasks planned on branch {branch}
 ✅ Implement complete — PR #{N} created with {M} commits
+✅ Docs complete — XML comments and markdown updated
 ✅ Review complete — approved
 ✅ Land complete — merged to main, label updated
 ```
@@ -105,7 +113,7 @@ Each stage agent manages its own label transitions.
 
 ## Important
 
-- **Never skip stages** — always run triage → plan → implement → review → land in order
+- **Never skip stages** — always run triage → plan → implement → docs → review → land in order
 - **Always delegate** — you are the orchestrator, not the executor
 - **Report progress** — the user should see what's happening at each stage
 - **Respect failures** — if something breaks, report it clearly rather than retrying infinitely


### PR DESCRIPTION
## 🎯 What's This?

The docs agent was living in implement's spare room. This evicts it with dignity.

## ✅ Quality Checks
- ⏭️ Build: Skipped (no .NET changes)
- ⏭️ Tests: Skipped (no .NET changes)
- ⏭️ Coverage: Skipped (no .NET changes)

## 💅 Changes

| File | What changed |
|------|-------------|
| \pipeline.agent.md\ | New Stage 4: docs — sits between implement and review, non-blocking |
| \implement.agent.md\ | Removed docs from agents list and task list — implement builds, it doesn't document |

## 🎪 Side Effects

Pipeline now goes: TRIAGE → PLAN → IMPLEMENT → DOCS → REVIEW → LAND

If docs fails, the pipeline shrugs and moves on to review. Docs was never load-bearing anyway.

---
*Auto-generated by the Snarky Commit Skill™*
*Powered by attitude and caffeine* ☕