### PR TITLE
🚦 The pipeline now refuses to plan without a triage paper trail

### DIFF
--- a/.github/agents/autopilot.agent.md
+++ b/.github/agents/autopilot.agent.md
@@ -38,6 +38,7 @@ When invoked with an issue number, you execute each stage in sequence by delegat
 - **GitHub actions:** reads issue, posts triage comment, manages labels
 - **STOP handling:** If triage returns `status: "STOP"`, halt the entire pipeline immediately. Report the stop reasons to the user. Do NOT proceed to Plan or any subsequent stage.
 - **DUPLICATE handling:** If triage returns `status: "DUPLICATE"`, halt the pipeline cleanly, report the canonical duplicate reference(s), treat the issue as already resolved or already in flight rather than as a pipeline failure, and move the issue out of active pipeline labels.
+- **Comment verification:** Before advancing to Plan, verify the issue thread contains the triage handoff comment with one of the required triage headings. If the comment is missing, treat triage as failed and do not proceed.
 
 ### Stage 2: Plan
 - **Delegate to:** `plan` agent
@@ -76,8 +77,13 @@ When invoked with an issue number, you execute each stage in sequence by delegat
 1. **Run all stages sequentially** — do not pause between stages
 2. **Pass the issue number** to each stage agent
 3. **Check for success** after each stage before proceeding
-4. **If review requests changes:** loop back to implement → review (max 2 cycles)
-5. **If any stage fails after retries:** halt and report failure
+4. **Verify issue-thread handoff artifacts** before advancing between stages when a stage is supposed to post one
+5. **If review requests changes:** loop back to implement → review (max 2 cycles)
+6. **If any stage fails after retries:** halt and report failure
+
+For Triage specifically, success requires both:
+- a non-error return status from the triage agent, and
+- a visible triage comment on the issue thread
 
 ## Review Loop
 

--- a/.github/agents/plan.agent.md
+++ b/.github/agents/plan.agent.md
@@ -28,18 +28,32 @@ Be meticulous, confident, slightly dramatic. You've never had a job go sideways 
 Given an issue number:
 
 1. **Read the issue** and all comments (especially the triage comment) via GitHub
-2. **Post a "Planning Started" comment** on the issue immediately — let watchers know the board is being studied
-3. **Research the codebase** — explore relevant files, find patterns and conventions
-4. **Post a "Research Complete" comment** summarizing key findings: patterns observed, load-bearing conventions, reuse opportunities — brief but in character
-5. **Create a detailed implementation plan** including:
+2. **Verify that a triage comment already exists** on the issue before doing anything else
+3. **Post a "Planning Started" comment** on the issue immediately — let watchers know the board is being studied
+4. **Research the codebase** — explore relevant files, find patterns and conventions
+5. **Post a "Research Complete" comment** summarizing key findings: patterns observed, load-bearing conventions, reuse opportunities — brief but in character
+6. **Create a detailed implementation plan** including:
    - Branch name: `feat/issue-{number}-{slugified-title-max-30-chars}`
    - Files to create/modify with specific descriptions of changes
    - Design decisions with rationale
    - Test plan
    - Acceptance criteria
-6. **Post the full plan comment** on the issue (format below)
-7. **Create the feature branch** from main
-8. **Post a "Branch Ready" comment** confirming the branch name — the opening is complete, implementation may begin
+7. **Post the full plan comment** on the issue (format below)
+8. **Create the feature branch** from main
+9. **Post a "Branch Ready" comment** confirming the branch name — the opening is complete, implementation may begin
+
+## Triage Handoff Gate
+
+Before posting any planning comment, you MUST confirm the issue already contains one of these triage headings:
+- `## 🕵️ Case File — Triage Report`
+- `## 🕵️ Case File — Investigation Halted`
+- `## 🕵️ Case File — Duplicate Located`
+
+If no triage comment exists:
+- Do NOT start planning
+- Do NOT post "Planning Started"
+- Return a failure explaining that triage did not publish its handoff comment
+- Tell the caller to rerun triage or fix the triage stage first
 
 ## Planning Process
 
@@ -89,6 +103,7 @@ Everything else — headings, prose, crew briefings, dramatic sign-offs — is p
 3. **Order by dependency** — later tasks can build on earlier ones.
 4. **Include tests** — every new public method needs a test.
 5. **Keep scope tight** — only plan what the issue asks for.
+6. **Never bypass triage** — if the issue thread lacks a triage handoff comment, stop.
 
 ## Return Value
 

--- a/.github/agents/triage.agent.md
+++ b/.github/agents/triage.agent.md
@@ -43,7 +43,19 @@ Given an issue number:
    - `testing` — unit tests, integration tests (always include if implementation agents are assigned)
    - `docs` — documentation updates (include for features and significant changes)
 5. **Post a triage comment** on the issue (format below)
-6. **Apply classification labels** — 1-2 type labels (bug/enhancement/feature/security/documentation/refactor)
+6. **Verify the comment posted successfully** before returning any summary object
+7. **Apply classification labels** — 1-2 type labels (bug/enhancement/feature/security/documentation/refactor)
+
+## Comment Posting Is Mandatory
+
+The triage issue comment is not optional and not best-effort. It is the handoff artifact for the rest of the pipeline.
+
+Rules:
+- Do NOT return a final summary until the triage comment is visible on the issue
+- If the comment post fails, retry once with the same content
+- If the retry also fails, return `status: "STOP"` with `stop_reasons` including `"triage comment could not be posted"`
+- Never silently continue after classification without a triage comment on the issue
+- The comment must land before Plan is allowed to start
 
 ## Triage Comment Format
 
@@ -89,10 +101,11 @@ If you mark an issue as duplicate, you MUST:
 1. Post a triage comment using the heading `## 🕵️ Case File — Duplicate Located`
 2. Cite the exact issue(s), PR(s), file(s), endpoint(s), or docs that prove it
 3. Explain whether the issue is already shipped or merely already in flight
-4. Return `status: "DUPLICATE"`
-5. Include `duplicate_of` with the canonical issue/PR reference(s)
-6. Still include `related_issues` and `related_prs` when relevant
-7. Apply the label `duplicate` when the repository uses it
+4. Verify the duplicate comment is visible on the issue
+5. Return `status: "DUPLICATE"`
+6. Include `duplicate_of` with the canonical issue/PR reference(s)
+7. Still include `related_issues` and `related_prs` when relevant
+8. Apply the label `duplicate` when the repository uses it
 
 ### Possible duplicate
 
@@ -109,14 +122,15 @@ Always capture associated work when it would help later stages:
 Related work is context, not a stop condition.
 
 ### If the issue PASSES the quality gate:
-Proceed with classification and post the triage comment as normal.
+Proceed with classification, post the triage comment, verify it is visible on the issue, and only then return your summary.
 
 ### If the issue FAILS the quality gate:
 1. Post a triage comment explaining what's missing/dangerous (in noir voice)
 2. Use the heading "## 🕵️ Case File — Investigation Halted"
 3. List the specific gaps (e.g., "No acceptance criteria", "Scope is three features in a trenchcoat pretending to be one issue")
-4. **Return `status: "STOP"`** — this halts the pipeline immediately
-5. Apply the label `needs-info` to the issue
+4. Verify the STOP comment is visible on the issue
+5. **Return `status: "STOP"`** — this halts the pipeline immediately
+6. Apply the label `needs-info` to the issue
 
 Example STOP comment:
 ```markdown


### PR DESCRIPTION
## 🎯 What's This?
This PR hardens the pipeline handoff so triage has to actually leave an issue comment before plan or autopilot can pretend the stage succeeded.

## ✅ Quality Checks
- [⏭️] Build: Skipped (no .NET changes)
- [⏭️] Tests: Skipped (no .NET changes)
- [⏭️] Coverage: Skipped (no .NET changes)

## 💅 Commit Messages
Forced triage to leave a paper trail before plan gets cute 🧾

## 🎪 Side Effects
Plan now blocks when triage ghosts the issue thread, which is exactly the kind of clingy behavior this pipeline needed.

---
*Auto-generated by the Snarky Commit Skill™*
*Powered by attitude and caffeine* ☕