### PR TITLE
🍪 Dark mode gets a real foundation: cookies, custom properties, and zero FOUC

### DIFF
--- a/Middleware/ThemePreferenceMiddleware.cs
+++ b/Middleware/ThemePreferenceMiddleware.cs
@@ -1,0 +1,80 @@
+using Demo1.Features;
+using Microsoft.FeatureManagement;
+
+namespace Demo1.Middleware;
+
+/// <summary>
+/// Middleware that reads the user's theme preference from a cookie and stores it in
+/// <see cref="HttpContext.Items"/> for use during response rendering. Suppressed entirely
+/// when the <c>DarkMode</c> feature flag is disabled.
+/// </summary>
+public class ThemePreferenceMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly IFeatureManager _featureManager;
+    private readonly ILogger<ThemePreferenceMiddleware> _logger;
+
+    private static readonly HashSet<string> AllowedThemes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "light", "dark", "auto"
+    };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThemePreferenceMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="featureManager">The feature manager used to evaluate the DarkMode flag.</param>
+    /// <param name="logger">The logger instance.</param>
+    public ThemePreferenceMiddleware(
+        RequestDelegate next,
+        IFeatureManager featureManager,
+        ILogger<ThemePreferenceMiddleware> logger)
+    {
+        _next = next;
+        _featureManager = featureManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Reads the <c>theme-preference</c> cookie and stores the validated value in
+    /// <c>HttpContext.Items["ThemePreference"]</c> when the <c>DarkMode</c> flag is enabled.
+    /// </summary>
+    /// <param name="context">The HTTP context for the current request.</param>
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!await _featureManager.IsEnabledAsync(FeatureFlags.DarkMode))
+        {
+            _logger.LogDebug("DarkMode flag off — theme middleware suppressed");
+            await _next(context);
+            return;
+        }
+
+        if (context.Request.Cookies.TryGetValue("theme-preference", out var theme) &&
+            AllowedThemes.Contains(theme))
+        {
+            context.Items["ThemePreference"] = theme.ToLowerInvariant();
+            _logger.LogInformation(
+                "Theme preference {Theme} applied from cookie for request {Path}",
+                theme,
+                context.Request.Path);
+        }
+
+        await _next(context);
+    }
+}
+
+/// <summary>
+/// Extension methods for adding <see cref="ThemePreferenceMiddleware"/> to the pipeline.
+/// </summary>
+public static class ThemePreferenceMiddlewareExtensions
+{
+    /// <summary>
+    /// Adds the <see cref="ThemePreferenceMiddleware"/> to the application pipeline.
+    /// </summary>
+    /// <param name="builder">The application builder.</param>
+    /// <returns>The application builder for chaining.</returns>
+    public static IApplicationBuilder UseThemePreference(this IApplicationBuilder builder)
+    {
+        return builder.UseMiddleware<ThemePreferenceMiddleware>();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -304,6 +304,7 @@ app.UseMiddleware<ServerTimingMiddleware>();
 app.UseSecurityHeaders();
 app.UseSecurityLabHeaders();
 app.UseStatusCodePagesWithReExecute("/Home/Error{0}");
+app.UseThemePreference();
 app.UseRouting();
 app.UseRateLimiter();
 app.UseRateLimitHeaders();

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -1,5 +1,5 @@
 ﻿<!DOCTYPE html>
-<html lang="en" data-bs-theme="light">
+<html lang="en" data-bs-theme="@(Context.Items["ThemePreference"] as string ?? "light")">
 
 <head>
     <meta charset="utf-8" />
@@ -9,6 +9,7 @@
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/theme.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/_.styles.css" asp-append-version="true" />
     @await RenderSectionAsync("Styles", required: false)
 </head>

--- a/architecture.md
+++ b/architecture.md
@@ -75,15 +75,16 @@ Order matters — this is the actual registration order in `Program.cs`:
 5. SecurityHeadersMiddleware         (custom — CSP, X-Frame-Options, etc.)
 6. SecurityLabMiddleware             (custom — relaxed headers for security lab pages)
 7. StatusCodePages                   (re-execute to /Home/Error{code})
-8. Routing
-9. RateLimiter                       (IP-based fixed-window)
-10. RateLimitHeadersMiddleware       (custom — X-RateLimit-* headers)
-11. Session                          (required for achievement tracking)
-12. AchievementMiddleware             (custom — publishes events to Channel<T>)
-13. AzureAppConfiguration            (feature flag refresh, when configured)
-14. Authorization
-15. Static Assets / Controllers
-16. Health Checks                    (/health/ready)
+8. ThemePreferenceMiddleware         (custom — reads theme-preference cookie; gated by DarkMode flag)
+9. Routing
+10. RateLimiter                       (IP-based fixed-window)
+11. RateLimitHeadersMiddleware       (custom — X-RateLimit-* headers)
+12. Session                          (required for achievement tracking)
+13. AchievementMiddleware             (custom — publishes events to Channel<T>)
+14. AzureAppConfiguration            (feature flag refresh, when configured)
+15. Authorization
+16. Static Assets / Controllers
+17. Health Checks                    (/health/ready)
 ```
 
 ## Custom Middleware
@@ -95,6 +96,7 @@ Order matters — this is the actual registration order in `Program.cs`:
 | `SecurityLabMiddleware` | Middleware/SecurityLabMiddleware.cs | Relaxes security headers on `/SecurityLab/*` routes for demo purposes |
 | `RateLimitHeadersMiddleware` | Middleware/RateLimitHeadersMiddleware.cs | Adds `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers |
 | `AchievementMiddleware` | Middleware/AchievementMiddleware.cs | Publishes request events to `Channel<AchievementEventMessage>` for async badge processing |
+| `ThemePreferenceMiddleware` | Middleware/ThemePreferenceMiddleware.cs | Reads `theme-preference` cookie and stores validated value in `HttpContext.Items`; suppressed entirely when `DarkMode` flag is off |
 
 ## Registered Services
 
@@ -175,7 +177,7 @@ Managed via Azure App Configuration (when configured) or local `appsettings.json
 | Flag | Purpose | Type |
 |------|---------|------|
 | `Feature1` | Example toggle | Permanent |
-| `DarkMode` | Dark mode UI toggle | Permanent |
+| `DarkMode` | Dark mode UI toggle — gates toggle visibility in navbar, `ThemePreferenceMiddleware` activation, and server-side FOUC prevention via cookie; default `false` | Permanent |
 | `ContactForm` | Contact form visibility | Permanent |
 | `BetaFeatures` | Master toggle for beta features | Permanent |
 

--- a/tests/Demo1.UnitTests/Middleware/ThemePreferenceMiddlewareTests.cs
+++ b/tests/Demo1.UnitTests/Middleware/ThemePreferenceMiddlewareTests.cs
@@ -1,0 +1,130 @@
+using Demo1.Features;
+using Demo1.Middleware;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Microsoft.FeatureManagement;
+using Moq;
+
+namespace Demo1.UnitTests.Middleware;
+
+/// <summary>
+/// Unit tests for <see cref="ThemePreferenceMiddleware"/> verifying flag-gating,
+/// cookie validation, and HttpContext.Items population.
+/// </summary>
+public class ThemePreferenceMiddlewareTests
+{
+    private static ThemePreferenceMiddleware CreateMiddleware(
+        RequestDelegate next,
+        bool darkModeEnabled,
+        out Mock<IFeatureManager> featureManagerMock)
+    {
+        featureManagerMock = new Mock<IFeatureManager>();
+        featureManagerMock
+            .Setup(fm => fm.IsEnabledAsync(FeatureFlags.DarkMode))
+            .ReturnsAsync(darkModeEnabled);
+
+        var logger = Mock.Of<ILogger<ThemePreferenceMiddleware>>();
+        return new ThemePreferenceMiddleware(next, featureManagerMock.Object, logger);
+    }
+
+    private static DefaultHttpContext CreateContextWithCookie(string? cookieValue = null)
+    {
+        var context = new DefaultHttpContext();
+        if (cookieValue is not null)
+        {
+            context.Request.Headers["Cookie"] = $"theme-preference={cookieValue}";
+        }
+        return context;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOff_SkipsMiddleware_CallsNext()
+    {
+        var nextCalled = false;
+        RequestDelegate next = ctx => { nextCalled = true; return Task.CompletedTask; };
+        var middleware = CreateMiddleware(next, darkModeEnabled: false, out _);
+        var context = CreateContextWithCookie("dark");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+        Assert.False(context.Items.ContainsKey("ThemePreference"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOn_NoCookie_CallsNext_NoItemSet()
+    {
+        var nextCalled = false;
+        RequestDelegate next = ctx => { nextCalled = true; return Task.CompletedTask; };
+        var middleware = CreateMiddleware(next, darkModeEnabled: true, out _);
+        var context = CreateContextWithCookie(); // no cookie
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+        Assert.False(context.Items.ContainsKey("ThemePreference"));
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOn_ValidDarkCookie_SetsItemToDark()
+    {
+        RequestDelegate next = _ => Task.CompletedTask;
+        var middleware = CreateMiddleware(next, darkModeEnabled: true, out _);
+        var context = CreateContextWithCookie("dark");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal("dark", context.Items["ThemePreference"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOn_ValidLightCookie_SetsItemToLight()
+    {
+        RequestDelegate next = _ => Task.CompletedTask;
+        var middleware = CreateMiddleware(next, darkModeEnabled: true, out _);
+        var context = CreateContextWithCookie("light");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal("light", context.Items["ThemePreference"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOn_ValidAutoCookie_SetsItemToAuto()
+    {
+        RequestDelegate next = _ => Task.CompletedTask;
+        var middleware = CreateMiddleware(next, darkModeEnabled: true, out _);
+        var context = CreateContextWithCookie("auto");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Equal("auto", context.Items["ThemePreference"]);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_FlagOn_InvalidCookieValue_DoesNotSetItem()
+    {
+        RequestDelegate next = _ => Task.CompletedTask;
+        var middleware = CreateMiddleware(next, darkModeEnabled: true, out _);
+        var context = CreateContextWithCookie("rainbow");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.False(context.Items.ContainsKey("ThemePreference"));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task InvokeAsync_AlwaysCallsNext(bool darkModeEnabled)
+    {
+        var nextCalled = false;
+        RequestDelegate next = ctx => { nextCalled = true; return Task.CompletedTask; };
+        var middleware = CreateMiddleware(next, darkModeEnabled, out _);
+        var context = CreateContextWithCookie("dark");
+
+        await middleware.InvokeAsync(context);
+
+        Assert.True(nextCalled);
+    }
+}

--- a/wwwroot/css/theme.css
+++ b/wwwroot/css/theme.css
@@ -1,0 +1,29 @@
+/* Theme palette — CSS custom properties for light/dark modes */
+
+html[data-bs-theme="light"] {
+    --bg-color: #ffffff;
+    --text-color: #212529;
+    --surface-color: #f8f9fa;
+    --border-color: #dee2e6;
+    --link-color: #0d6efd;
+    --nav-bg: #ffffff;
+    --footer-bg: #f8f9fa;
+    --card-bg: #ffffff;
+    --muted-text: #6c757d;
+    --input-bg: #ffffff;
+    --input-border: #ced4da;
+}
+
+html[data-bs-theme="dark"] {
+    --bg-color: #212529;
+    --text-color: #f8f9fa;
+    --surface-color: #2c3034;
+    --border-color: #495057;
+    --link-color: #6ea8fe;
+    --nav-bg: #343a40;
+    --footer-bg: #2c3034;
+    --card-bg: #343a40;
+    --muted-text: #adb5bd;
+    --input-bg: #2c3034;
+    --input-border: #495057;
+}

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -10,8 +10,15 @@
 (() => {
     'use strict';
 
-    const getStoredTheme = () => localStorage.getItem('theme');
-    const setStoredTheme = theme => localStorage.setItem('theme', theme);
+    // Runs unconditionally — safe no-op when DarkMode flag is off
+    // (no cookie exists for users; toggle UI is hidden by the feature gate)
+    const getStoredTheme = () => {
+        const match = document.cookie.match('(?:^|;)\\s*theme-preference=([^;]*)');
+        return match ? decodeURIComponent(match[1]) : null;
+    };
+    const setStoredTheme = theme => {
+        document.cookie = `theme-preference=${theme}; max-age=31536000; path=/; SameSite=Strict`;
+    };
 
     const getSystemPreferredTheme = () => {
         return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';


### PR DESCRIPTION
## What's This?

The \DarkMode\ flag has been sitting at \alse\ since PR #22 landed last November. The toggle worked, but it relied on \localStorage\ (server-blind), had no CSS custom property palette, and let the flash-of-wrong-theme sneak in every load. This PR closes all three gaps — server-side FOUC prevention via middleware, a proper \	heme.css\ palette, and cookie-backed preference storage.

Everything ships behind \DarkMode: false\. The flag is already the gate. No new flags. No accidental enablement. Enabling \DarkMode: true\ is a deliberate human operator step.

---

## What Changed

| File | Action | Notes |
|------|--------|-------|
| \wwwroot/css/theme.css\ | **Created** | CSS custom property palette for light + dark modes |
| \Middleware/ThemePreferenceMiddleware.cs\ | **Created** | Reads \	heme-preference\ cookie; gates on \DarkMode\ flag |
| \Program.cs\ | **Modified** | \pp.UseThemePreference()\ registered before routing |
| \Views/Shared/_Layout.cshtml\ | **Modified** | \data-bs-theme\ from \Context.Items\; \	heme.css\ linked |
| \wwwroot/js/site.js\ | **Modified** | \localStorage\ → cookie storage (safe no-op when flag off) |
| \	ests/Demo1.UnitTests/Middleware/ThemePreferenceMiddlewareTests.cs\ | **Created** | 7 unit tests, all green |

---

## Quality Checks

- ✅ **Build:** \dotnet build --configuration Release\ — succeeded (145 pre-existing warnings, 0 errors)
- ✅ **Tests:** 226 passed, 0 failed — includes all 7 new \ThemePreferenceMiddlewareTests\
- ✅ **Flag gating:** middleware suppresses entirely when \DarkMode = false\; no side effects leak
- ✅ **FOUC prevention:** server reads cookie → sets \data-bs-theme\ on \<html>\ before paint
- ✅ **Cookie is safe:** invalid values rejected; missing cookie is a no-op

---

## Commit

\\\
feat(middleware): ThemePreferenceMiddleware reads cookie before paint — FOUC has left the building 🍪
\\\

---

## Rollout Notes

- **Flag:** \FeatureFlags.DarkMode\ (permanent, default \alse\)
- **Flag off behavior:** Toggle UI hidden; \data-bs-theme\ hardcoded \light\; middleware suppressed; \site.js\ cookie ops are no-ops (no cookie for unauthenticated users)
- **Flag on behavior:** Toggle renders; CSS custom properties active; cookie → server-side theme; FOUC eliminated
- **Activation:** Set \FeatureManagement:DarkMode = true\ in Azure App Configuration. Do NOT commit \	rue\ to \ppsettings.json\.
- **Rollback:** Flip flag back to \alse\ — toggle disappears instantly; existing browser cookies are harmless

---

Refs #172